### PR TITLE
Move generichas state into the cpp file as a global so that I can kee…

### DIFF
--- a/Modules/Cryptography/Esp/CryptographyModule.cpp
+++ b/Modules/Cryptography/Esp/CryptographyModule.cpp
@@ -3,6 +3,10 @@
 //C++
 #include <cstring>
 #include <cstdarg>
+//Sodium
+#include "sodium.h"
+
+crypto_generichash_state genericHashState;
 
 Cryptography::Cryptography(const std::string &privateStaticKey, Bytes keySize) : CryptographyAbstraction(privateStaticKey, keySize) {
     const bool noExistingKeyIsStored = privateStaticKey.empty();

--- a/Modules/Cryptography/Esp/CryptographyModule.hpp
+++ b/Modules/Cryptography/Esp/CryptographyModule.hpp
@@ -3,8 +3,6 @@
 
 //Foundation
 #include "CryptographyAbstraction.hpp"
-//Sodium
-#include "sodium.h"
 
 class Cryptography : public CryptographyAbstraction {
     
@@ -20,8 +18,6 @@ class Cryptography : public CryptographyAbstraction {
     ErrorType hash(HashFunction hashFunction, const std::string &key, const std::string &data, std::string hashedData, const HashPart hashPart) override;
 
     private:
-    crypto_generichash_state genericHashState;
-    
     ErrorType generateKeysX25519();
     ErrorType generateKeysEllipticCurveDiffieHellman();
     ErrorType generatePrivateKeyEllipticCurveDiffieHellman(const std::string &myPrivateKey, const std::string &theirPublicKey, std::string &newPrivateKey);

--- a/Modules/Cryptography/Linux/CryptographyModule.cpp
+++ b/Modules/Cryptography/Linux/CryptographyModule.cpp
@@ -3,6 +3,10 @@
 //C++
 #include <cstring>
 #include <cstdarg>
+//Sodium
+#include "sodium.h"
+
+crypto_generichash_state genericHashState;
 
 Cryptography::Cryptography(const std::string &privateStaticKey, Bytes keySize) : CryptographyAbstraction(privateStaticKey, keySize) {
     const bool noExistingKeyIsStored = privateStaticKey.empty();

--- a/Modules/Cryptography/Linux/CryptographyModule.hpp
+++ b/Modules/Cryptography/Linux/CryptographyModule.hpp
@@ -3,8 +3,6 @@
 
 //AbstractionLayer
 #include "CryptographyAbstraction.hpp"
-//Sodium
-#include "sodium.h"
 
 class Cryptography : public CryptographyAbstraction {
     
@@ -20,8 +18,6 @@ class Cryptography : public CryptographyAbstraction {
     ErrorType hash(HashFunction hashFunction, const std::string &key, const std::string &data, std::string hashedData, const HashPart hashPart) override;
 
     private:
-    crypto_generichash_state genericHashState;
-
     ErrorType generateKeysX25519();
     ErrorType generateKeysEllipticCurveDiffieHellman();
     ErrorType generatePrivateKeyEllipticCurveDiffieHellman(const std::string &myPrivateKey, const std::string &theirPublicKey, std::string &newPrivateKey);

--- a/Modules/Cryptography/MacOs/CryptographyModule.cpp
+++ b/Modules/Cryptography/MacOs/CryptographyModule.cpp
@@ -2,6 +2,10 @@
 #include "CryptographyModule.hpp"
 //C++
 #include <cstring>
+//Sodium
+#include "sodium.h"
+
+crypto_generichash_state genericHashState;
 
 Cryptography::Cryptography(const std::string &privateStaticKey, Bytes keySize) : CryptographyAbstraction(privateStaticKey, keySize) {
     const bool noExistingKeyIsStored = privateStaticKey.empty();

--- a/Modules/Cryptography/MacOs/CryptographyModule.hpp
+++ b/Modules/Cryptography/MacOs/CryptographyModule.hpp
@@ -3,8 +3,6 @@
 
 //AbstractionLayer
 #include "CryptographyAbstraction.hpp"
-//Sodium
-#include "sodium.h"
 
 class Cryptography : public CryptographyAbstraction {
     
@@ -20,8 +18,6 @@ class Cryptography : public CryptographyAbstraction {
     ErrorType hash(HashFunction hashFunction, const std::string &key, const std::string &data, std::string hashedData, const HashPart hashPart) override;
 
     private:
-    crypto_generichash_state genericHashState;
-    
     ErrorType generateKeysX25519();
     ErrorType generateKeysEllipticCurveDiffieHellman();
     ErrorType generatePrivateKeyEllipticCurveDiffieHellman(const std::string &myPrivateKey, const std::string &theirPublicKey, std::string &newPrivateKey);


### PR DESCRIPTION
…p sodium out of the header files.