### PR TITLE
getMacAddress is unavailable for cellular networks because cell netwo…

### DIFF
--- a/Modules/Network/Cellular/QuectelEC21A/CellularModule.cpp
+++ b/Modules/Network/Cellular/QuectelEC21A/CellularModule.cpp
@@ -164,8 +164,11 @@ ErrorType Cellular::rxNonBlocking(std::shared_ptr<std::string> frameBuffer, std:
     return ErrorType::NotImplemented;
 }
 
+//https://iot.stackexchange.com/questions/5705/getting-ip-and-mac-address-of-lte-modem-using-at-commands
+//https://networkengineering.stackexchange.com/questions/77606/mobile-cellular-networks-gsm-lte-5g-and-mac-addresses#:~:text=Mobile%20devices%20don't%20use,service%2C%20they%20use%20IMEI%20addresses./
+//Cell networks don't use a MAC address.
 ErrorType Cellular::getMacAddress(std::string &macAddress) {
-    return ErrorType::NotImplemented;
+    return ErrorType::NotAvailable;
 }
 
 ErrorType Cellular::getSignalStrength(DecibelMilliWatts &signalStrength) {

--- a/Modules/Network/Wifi/Esp/WifiModule.cpp
+++ b/Modules/Network/Wifi/Esp/WifiModule.cpp
@@ -165,6 +165,7 @@ ErrorType Wifi::rxBlocking(std::string &frameBuffer, const Milliseconds timeout)
 ErrorType Wifi::rxNonBlocking(std::shared_ptr<std::string> frameBuffer, std::function<void(const ErrorType error, std::shared_ptr<std::string> frameBuffer)> callback) {
     return ErrorType::NotImplemented;
 }
+
 ErrorType Wifi::getMacAddress(std::string &macAddress) {
     uint8_t macAddressByteArray[6];
     constexpr Count macAddressStringSize = 17;
@@ -181,6 +182,7 @@ ErrorType Wifi::getMacAddress(std::string &macAddress) {
 
     return ErrorType::Success;
 }
+
 ErrorType Wifi::getSignalStrength(DecibelMilliWatts &signalStrength) {
     int signalStrengthRssi;
     esp_wifi_sta_get_rssi(&signalStrengthRssi);


### PR DESCRIPTION
…rks don't use a mac address. I could maybe make this just return the IMEI but probably best to include a new function in the cellular abstraction for that.